### PR TITLE
Fix PHPStan Errors

### DIFF
--- a/src/Data/DiscoveredClass.php
+++ b/src/Data/DiscoveredClass.php
@@ -8,7 +8,6 @@ use Spatie\StructureDiscoverer\Enums\DiscoveredStructureType;
 use Spatie\StructureDiscoverer\Exceptions\InvalidReflection;
 
 /**
- * @property array<string> $extends
  * @property array<string> $implements
  * @property array<DiscoveredAttribute> $attributes
  * @property ?array<string> $extendsChain


### PR DESCRIPTION
This PR should resolve the PHPStan errors due to an invalid PHP doc block.

The `$extends` property cannot be an array of strings:

https://github.com/spatie/php-structure-discoverer/blob/ec6ecd1412fe7781901607f571232b36ef50f960/src/Data/DiscoveredClass.php#L26