### PR TITLE
Updated README.md - fixed typo in classname

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ class FormRequest extends Request
 {
 }
 
-class UserFormRequest extends Request
+class UserFormRequest extends FormRequest
 {
 }
 ```


### PR DESCRIPTION
Classname to extend should be `FormRequest` according to the semantics in the text description below.