### PR TITLE
Docs - Fix config publish command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ composer require spatie/php-structure-discoverer
 If you're using Laravel, then you can also publish the config file with the following command:
 
 ```bash
-php artisan vendor:publish --tag="php-structure-discoverer-config"
+php artisan vendor:publish --tag="structure-discoverer-config"
 ```
 
 This is the contents of the published config file:


### PR DESCRIPTION
The publish command should exclude `php-`:

https://github.com/spatie/php-structure-discoverer/blob/8c084e3c22c465504bb19be9c52337fd69154f49/src/StructureDiscovererServiceProvider.php#L16