### PR TITLE
Fix typo in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ You can also use caching inline without the use of scouts, be aware warming up t
 
 ```php
 Discover::in(__DIR__)
-   ->cache(
+   ->withCache(
       'Some identifier',
       new FileDiscoverCacheDriver('/path/to/temp/directory);
    )


### PR DESCRIPTION
Seems the method is `withCache` instead of `cache`.