### PR TITLE
Fix parsing classes containing anonymous classes

### DIFF
--- a/src/TokenParsers/FileTokenParser.php
+++ b/src/TokenParsers/FileTokenParser.php
@@ -5,7 +5,6 @@ namespace Spatie\StructureDiscoverer\TokenParsers;
 use Spatie\StructureDiscoverer\Collections\TokenCollection;
 use Spatie\StructureDiscoverer\Collections\UsageCollection;
 use Spatie\StructureDiscoverer\Data\DiscoveredStructure;
-use Spatie\StructureDiscoverer\Data\Token;
 use Spatie\StructureDiscoverer\Enums\DiscoveredStructureType;
 use Spatie\StructureDiscoverer\Exceptions\CouldNotParseFile;
 use Throwable;
@@ -20,7 +19,6 @@ class FileTokenParser
     ) {
     }
 
-    /** @return array<DiscoveredStructure> */
     public function execute(
         string $filename,
         string $contents,
@@ -39,8 +37,7 @@ class FileTokenParser
         $structureDefined = false;
 
         $index = 0;
-
-
+        
         try {
             do {
                 if ($tokens->get($index)->is(T_NAMESPACE)) {
@@ -74,6 +71,15 @@ class FileTokenParser
                     continue;
                 }
 
+                if (
+                    $type === DiscoveredStructureType::ClassDefinition
+                    && $this->isAnonymousClass($tokens, $index)
+                ) {
+                    $index++;
+
+                    continue;
+                }
+
                 $discoveredStructure = $this->discoveredDataResolver->execute(
                     $index + 1,
                     $tokens,
@@ -96,5 +102,22 @@ class FileTokenParser
         }
 
         return $found;
+    }
+
+    private function isAnonymousClass(TokenCollection $tokens, int $index): bool
+    {
+        $prevIndex = $index - 1;
+
+        // find the previous non-whitespace token
+        while ($prevIndex >= 0 && $tokens->get($prevIndex)->is(T_WHITESPACE)) {
+            $prevIndex--;
+        }
+
+        // if the token before T_CLASS is T_NEW, it's an anonymous class
+        if ($prevIndex >= 0 && $tokens->get($prevIndex)->is(T_NEW)) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/TokenParsers/FileTokenParser.php
+++ b/src/TokenParsers/FileTokenParser.php
@@ -19,6 +19,7 @@ class FileTokenParser
     ) {
     }
 
+    /** @return array<DiscoveredStructure> */
     public function execute(
         string $filename,
         string $contents,
@@ -37,7 +38,7 @@ class FileTokenParser
         $structureDefined = false;
 
         $index = 0;
-        
+
         try {
             do {
                 if ($tokens->get($index)->is(T_NAMESPACE)) {

--- a/tests/Fakes/FakeWithAnonymousClass.php
+++ b/tests/Fakes/FakeWithAnonymousClass.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\StructureDiscoverer\Tests\Fakes;
+
+class FakeWithAnonymousClass
+{
+    public function foo(): object
+    {
+        return new class() {
+            public function bar(): string {
+                return 'baz';
+            }
+        };
+    }
+}

--- a/tests/Fakes/FakeWithMultipleClasses.php
+++ b/tests/Fakes/FakeWithMultipleClasses.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\StructureDiscoverer\Tests\Fakes;
+
+class FakeWithMultipleClasses
+{
+}
+
+class FakeWithMultipleClassesSub
+{
+}

--- a/tests/ReflectionTest.php
+++ b/tests/ReflectionTest.php
@@ -21,6 +21,8 @@ use Spatie\StructureDiscoverer\Tests\Fakes\FakeStringEnum;
 use Spatie\StructureDiscoverer\Tests\Fakes\FakeSubChildClass;
 use Spatie\StructureDiscoverer\Tests\Fakes\FakeSubChildInterface;
 use Spatie\StructureDiscoverer\Tests\Fakes\FakeTrait;
+use Spatie\StructureDiscoverer\Tests\Fakes\FakeWithAnonymousClass;
+use Spatie\StructureDiscoverer\Tests\Fakes\FakeWithMultipleClasses;
 use Spatie\StructureDiscoverer\Tests\Fakes\Nested\FakeNestedClass;
 use Spatie\StructureDiscoverer\Tests\Fakes\Nested\FakeNestedInterface;
 use Spatie\StructureDiscoverer\Tests\Fakes\OtherNested\FakeOtherNestedClass;
@@ -116,7 +118,9 @@ it('can discover using reflection', function () {
         FakeOtherNestedClass::class,
         FakeSubChildInterface::class,
         FakeSubChildClass::class,
+        FakeWithMultipleClasses::class,
         FakeClassDepender::class,
         FakeInterfaceDepender::class,
+        FakeWithAnonymousClass::class,
     ]);
 });

--- a/tests/StructureDiscovererTest.php
+++ b/tests/StructureDiscovererTest.php
@@ -511,7 +511,7 @@ it('can use a profile condition', function () {
 });
 
 it('can discover enums with interfaces', function () {
-    $found = Discover::in(__DIR__ . '/Fakes')
+    $found = Discover::in(__DIR__.'/Fakes')
         ->implementing(FakeChildInterface::class)
         ->enums()
         ->get();
@@ -524,13 +524,13 @@ it('can discover enums with interfaces', function () {
 });
 
 it('can parse anonymous classes', function () {
-    $found = Discover::in(__DIR__ . '/Fakes')->get();
+    $found = Discover::in(__DIR__.'/Fakes')->get();
 
     expect($found)->not->toContain("Spatie\StructureDiscoverer\Tests\Fakes\(");
 });
 
 it('can parse multiple nested classes', function () {
-    $found = Discover::in(__DIR__ . '/Fakes')->get();
+    $found = Discover::in(__DIR__.'/Fakes')->get();
 
     expect($found)->toContain("Spatie\StructureDiscoverer\Tests\Fakes\FakeWithMultipleClassesSub");
 });

--- a/tests/StructureDiscovererTest.php
+++ b/tests/StructureDiscovererTest.php
@@ -30,6 +30,9 @@ use Spatie\StructureDiscoverer\Tests\Fakes\Nested\FakeNestedClass;
 use Spatie\StructureDiscoverer\Tests\Fakes\Nested\FakeNestedInterface;
 use Spatie\StructureDiscoverer\Tests\Fakes\OtherNested\FakeOtherNestedClass;
 use Spatie\StructureDiscoverer\Tests\Stubs\StubStructureScout;
+use Spatie\StructureDiscoverer\Tests\Fakes\FakeWithAnonymousClass;
+use Spatie\StructureDiscoverer\Tests\Fakes\FakeWithMultipleClasses;
+use Spatie\StructureDiscoverer\Tests\Fakes\FakeWithMultipleClassesSub;
 
 beforeEach(function () {
     StaticDiscoverCacheDriver::clear();
@@ -55,6 +58,9 @@ it('can discover everything within a directory', function () {
         FakeSubChildClass::class,
         FakeClassDepender::class,
         FakeInterfaceDepender::class,
+        FakeWithAnonymousClass::class,
+        FakeWithMultipleClasses::class,
+        FakeWithMultipleClassesSub::class,
     ]);
 });
 
@@ -310,6 +316,9 @@ it('can sort discovered files', function (
                 FakeChildClass::class,
                 FakeRootClass::class,
                 FakeSubChildClass::class,
+                FakeWithAnonymousClass::class,
+                FakeWithMultipleClasses::class,
+                FakeWithMultipleClassesSub::class,
                 FakeNestedClass::class,
                 FakeOtherNestedClass::class,
             ],
@@ -331,6 +340,9 @@ it('can sort discovered files in reverse', function (
             [
                 FakeOtherNestedClass::class,
                 FakeNestedClass::class,
+                FakeWithMultipleClasses::class,
+                FakeWithMultipleClassesSub::class,
+                FakeWithAnonymousClass::class,
                 FakeSubChildClass::class,
                 FakeRootClass::class,
                 FakeChildClass::class,
@@ -506,4 +518,15 @@ it('can discover enums with interfaces', function () {
         FakeStringEnum::class,
         FakeIntEnum::class,
     ]);
+
+it('can parse anonymous classes', function () {
+    $found = Discover::in(__DIR__ . '/Fakes')->get();
+
+    expect($found)->not->toContain("Spatie\StructureDiscoverer\Tests\Fakes\(");
+});
+
+it('can parse multiple nested classes', function () {
+    $found = Discover::in(__DIR__ . '/Fakes')->get();
+
+    expect($found)->toContain("Spatie\StructureDiscoverer\Tests\Fakes\FakeWithMultipleClassesSub");
 });

--- a/tests/StructureDiscovererTest.php
+++ b/tests/StructureDiscovererTest.php
@@ -83,6 +83,9 @@ it('can only discover certain types', function (
                 FakeOtherNestedClass::class,
                 FakeSubChildClass::class,
                 FakeClassDepender::class,
+                FakeWithAnonymousClass::class,
+                FakeWithMultipleClasses::class,
+                FakeWithMultipleClassesSub::class,
             ],
         ],
         'interfaces' => [
@@ -508,7 +511,7 @@ it('can use a profile condition', function () {
 });
 
 it('can discover enums with interfaces', function () {
-    $found = Discover::in(__DIR__.'/Fakes')
+    $found = Discover::in(__DIR__ . '/Fakes')
         ->implementing(FakeChildInterface::class)
         ->enums()
         ->get();
@@ -518,6 +521,7 @@ it('can discover enums with interfaces', function () {
         FakeStringEnum::class,
         FakeIntEnum::class,
     ]);
+});
 
 it('can parse anonymous classes', function () {
     $found = Discover::in(__DIR__ . '/Fakes')->get();


### PR DESCRIPTION
This PR patches a bug I discovered when it parses a class containing an anonymous class.

When one is encountered, a FQCN is returned in the result with the basename of `(` or `{`, after the FQCN of the one that contained the anonymous class.

For example, if you remove the `isAnonymousClass` method included in this PR, the below entry is returned in the class list:

```php
$found = Discover::in(__DIR__ . '/Fakes')->get();

var_dump($found); // [..., "Spatie\StructureDiscoverer\Tests\Fakes\(", ...]
```

I've added a test case to ensure this is resolved, and have also added a case for ensuring files containing multiple class names can be returned as well.