### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,19 +13,21 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         php: [8.3, 8.4, 8.5]
-        laravel: ['11.*', '12.*']
+        laravel: ['11.*', '12.*', '13.*']
         stability: [prefer-lowest, prefer-stable]
-
+        exclude:
+          - laravel: '13.*'
+            php: 8.3
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,15 @@
     ],
     "require": {
         "php": "^8.3",
-        "illuminate/collections": "^11.0|^12.0",
+        "illuminate/collections": "^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.92.7",
         "symfony/finder": "^6.0|^7.3.5|^8.0"
     },
     "require-dev": {
         "amphp/parallel": "^2.3.2",
-        "illuminate/console": "^11.0|^12.0",
+        "illuminate/console": "^11.0|^12.0|^13.0",
         "nunomaduro/collision": "^7.0|^8.8.3",
-        "orchestra/testbench": "^9.5|^10.8",
+        "orchestra/testbench": "^9.5|^10.8|^11.0",
         "pestphp/pest": "^3.8|^4.0",
         "pestphp/pest-plugin-laravel": "^3.2|^4.0",
         "phpstan/extension-installer": "^1.4.3",


### PR DESCRIPTION
## Summary
- Add `^13.0` to `illuminate/collections` and `illuminate/console` constraints
- Add `^11.0` to `orchestra/testbench` constraint
- Add Laravel 13 to CI matrix with PHP 8.4+ exclusion
- Set `fail-fast: false` and bump `actions/checkout` to v6