### PR TITLE
Fix modifier detection for classes with multiple modifiers

### DIFF
--- a/src/TokenParsers/DiscoveredClassTokenParser.php
+++ b/src/TokenParsers/DiscoveredClassTokenParser.php
@@ -44,26 +44,42 @@ class DiscoveredClassTokenParser
         int $index,
         TokenCollection $tokens,
     ): bool {
-        $token = $tokens->get($index - 2);
-
-        return $token && $token->is(T_FINAL);
+        return $this->hasModifier($index, $tokens, T_FINAL);
     }
 
     protected function isClassReadonly(
         int $index,
         TokenCollection $tokens,
     ): bool {
-        $token = $tokens->get($index - 2);
-
-        return defined('T_READONLY') && $token && $token->is(T_READONLY);
+        return defined('T_READONLY') && $this->hasModifier($index, $tokens, T_READONLY);
     }
 
     protected function isClassAbstract(
         int $index,
         TokenCollection $tokens,
     ): bool {
-        $token = $tokens->get($index - 2);
+        return $this->hasModifier($index, $tokens, T_ABSTRACT);
+    }
 
-        return $token && $token->is(T_ABSTRACT);
+    private function hasModifier(int $index, TokenCollection $tokens, int $tokenType): bool
+    {
+        $modifiers = [T_ABSTRACT, T_FINAL];
+        if (defined('T_READONLY')) {
+            $modifiers[] = T_READONLY;
+        }
+
+        // $index points to the class name (T_STRING), $index - 1 is T_CLASS.
+        // Walk backwards from $index - 2 through any modifier tokens.
+        for ($i = $index - 2; $i >= 0; $i--) {
+            $token = $tokens->get($i);
+            if ($token === null || ! $token->is($modifiers)) {
+                break;
+            }
+            if ($token->is($tokenType)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/TokenParsers/DiscoveredClassTokenParser.php
+++ b/src/TokenParsers/DiscoveredClassTokenParser.php
@@ -44,42 +44,50 @@ class DiscoveredClassTokenParser
         int $index,
         TokenCollection $tokens,
     ): bool {
-        return $this->hasModifier($index, $tokens, T_FINAL);
+        return in_array(T_FINAL, $this->classModifiers($index, $tokens), true);
     }
 
     protected function isClassReadonly(
         int $index,
         TokenCollection $tokens,
     ): bool {
-        return defined('T_READONLY') && $this->hasModifier($index, $tokens, T_READONLY);
+        return defined('T_READONLY')
+            && in_array(T_READONLY, $this->classModifiers($index, $tokens), true);
     }
 
     protected function isClassAbstract(
         int $index,
         TokenCollection $tokens,
     ): bool {
-        return $this->hasModifier($index, $tokens, T_ABSTRACT);
+        return in_array(T_ABSTRACT, $this->classModifiers($index, $tokens), true);
     }
 
-    private function hasModifier(int $index, TokenCollection $tokens, int $tokenType): bool
+    /**
+     * Collects modifier token ids preceding the class keyword.
+     *
+     * $index points at the class name. $index - 1 is T_CLASS, so we walk
+     * backwards from $index - 2 collecting consecutive modifier tokens.
+     *
+     * @return array<int>
+     */
+    private function classModifiers(int $index, TokenCollection $tokens): array
     {
-        $modifiers = [T_ABSTRACT, T_FINAL];
-        if (defined('T_READONLY')) {
-            $modifiers[] = T_READONLY;
-        }
+        $allowed = defined('T_READONLY')
+            ? [T_ABSTRACT, T_FINAL, T_READONLY]
+            : [T_ABSTRACT, T_FINAL];
 
-        // $index points to the class name (T_STRING), $index - 1 is T_CLASS.
-        // Walk backwards from $index - 2 through any modifier tokens.
+        $modifiers = [];
+
         for ($i = $index - 2; $i >= 0; $i--) {
             $token = $tokens->get($i);
-            if ($token === null || ! $token->is($modifiers)) {
+
+            if ($token === null || ! $token->is($allowed)) {
                 break;
             }
-            if ($token->is($tokenType)) {
-                return true;
-            }
+
+            $modifiers[] = $token->id;
         }
 
-        return false;
+        return $modifiers;
     }
 }

--- a/tests/TokenParsersTest.php
+++ b/tests/TokenParsersTest.php
@@ -363,6 +363,39 @@ PHP;
         ->isAbstract->toBeTrue();
 });
 
+it('can resolve an abstract readonly class', function () {
+    $definition = <<<'PHP'
+    abstract readonly class BaseClass{}
+PHP;
+
+    expect(getDiscoveredStructure($definition))
+        ->toBeInstanceOf(DiscoveredClass::class)
+        ->isAbstract->toBeTrue()
+        ->isReadonly->toBeTrue();
+});
+
+it('can resolve a readonly abstract class', function () {
+    $definition = <<<'PHP'
+    readonly abstract class BaseClass{}
+PHP;
+
+    expect(getDiscoveredStructure($definition))
+        ->toBeInstanceOf(DiscoveredClass::class)
+        ->isAbstract->toBeTrue()
+        ->isReadonly->toBeTrue();
+});
+
+it('can resolve a final readonly class', function () {
+    $definition = <<<'PHP'
+    final readonly class BaseClass{}
+PHP;
+
+    expect(getDiscoveredStructure($definition))
+        ->toBeInstanceOf(DiscoveredClass::class)
+        ->isFinal->toBeTrue()
+        ->isReadonly->toBeTrue();
+});
+
 /**
  * Attributes
  */

--- a/tests/TokenParsersTest.php
+++ b/tests/TokenParsersTest.php
@@ -363,6 +363,18 @@ PHP;
         ->isAbstract->toBeTrue();
 });
 
+it('can resolve a readonly class', function () {
+    $definition = <<<'PHP'
+    readonly class BaseClass{}
+PHP;
+
+    expect(getDiscoveredStructure($definition))
+        ->toBeInstanceOf(DiscoveredClass::class)
+        ->isReadonly->toBeTrue()
+        ->isFinal->toBeFalse()
+        ->isAbstract->toBeFalse();
+});
+
 it('can resolve an abstract readonly class', function () {
     $definition = <<<'PHP'
     abstract readonly class BaseClass{}
@@ -371,7 +383,8 @@ PHP;
     expect(getDiscoveredStructure($definition))
         ->toBeInstanceOf(DiscoveredClass::class)
         ->isAbstract->toBeTrue()
-        ->isReadonly->toBeTrue();
+        ->isReadonly->toBeTrue()
+        ->isFinal->toBeFalse();
 });
 
 it('can resolve a readonly abstract class', function () {
@@ -382,7 +395,8 @@ PHP;
     expect(getDiscoveredStructure($definition))
         ->toBeInstanceOf(DiscoveredClass::class)
         ->isAbstract->toBeTrue()
-        ->isReadonly->toBeTrue();
+        ->isReadonly->toBeTrue()
+        ->isFinal->toBeFalse();
 });
 
 it('can resolve a final readonly class', function () {
@@ -393,7 +407,34 @@ PHP;
     expect(getDiscoveredStructure($definition))
         ->toBeInstanceOf(DiscoveredClass::class)
         ->isFinal->toBeTrue()
-        ->isReadonly->toBeTrue();
+        ->isReadonly->toBeTrue()
+        ->isAbstract->toBeFalse();
+});
+
+it('can resolve a readonly final class', function () {
+    $definition = <<<'PHP'
+    readonly final class BaseClass{}
+PHP;
+
+    expect(getDiscoveredStructure($definition))
+        ->toBeInstanceOf(DiscoveredClass::class)
+        ->isFinal->toBeTrue()
+        ->isReadonly->toBeTrue()
+        ->isAbstract->toBeFalse();
+});
+
+it('does not detect modifiers from a preceding class', function () {
+    $definition = <<<'PHP'
+    final class FirstClass{}
+
+    class SecondClass{}
+PHP;
+
+    expect(getDiscoveredStructure($definition, structure: 'SecondClass'))
+        ->toBeInstanceOf(DiscoveredClass::class)
+        ->isFinal->toBeFalse()
+        ->isAbstract->toBeFalse()
+        ->isReadonly->toBeFalse();
 });
 
 /**


### PR DESCRIPTION
Related to #37 

The isClassAbstract/isFinal/isReadonly methods hardcoded index - 2, assuming a single modifier before `class`. When two modifiers are combined (e.g. `abstract readonly class`), the token positions shift and detection fails.

Replaced the three duplicated lookups with a shared hasModifier() helper that walks backward through consecutive modifier tokens, correctly handling any combination of abstract/final/readonly.