### PR TITLE
Fix #42: discover models extending package models

### DIFF
--- a/src/Support/StructureChainResolver.php
+++ b/src/Support/StructureChainResolver.php
@@ -46,7 +46,14 @@ class StructureChainResolver
         }
 
         if (! array_key_exists($structure->extends, $discovered)) {
-            $structure->extendsChain = [$structure->extends];
+            $parents = class_exists($structure->extends)
+                ? array_values(class_parents($structure->extends))
+                : [];
+
+            $structure->extendsChain = [
+                $structure->extends,
+                ...$parents,
+            ];
 
             return;
         }

--- a/tests/Fixtures/Models/FakeUser.php
+++ b/tests/Fixtures/Models/FakeUser.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\StructureDiscoverer\Tests\Fixtures\Models;
+
+use Spatie\StructureDiscoverer\Tests\Fixtures\PackageModels\FakePackageUser;
+
+class FakeUser extends FakePackageUser
+{
+}

--- a/tests/Fixtures/PackageModels/FakePackageUser.php
+++ b/tests/Fixtures/PackageModels/FakePackageUser.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\StructureDiscoverer\Tests\Fixtures\PackageModels;
+
+use Illuminate\Database\Eloquent\Model;
+
+class FakePackageUser extends Model
+{
+}

--- a/tests/StructureDiscovererTest.php
+++ b/tests/StructureDiscovererTest.php
@@ -2,6 +2,7 @@
 
 use function Pest\Laravel\artisan;
 
+use Illuminate\Database\Eloquent\Model;
 use Spatie\StructureDiscoverer\Cache\FileDiscoverCacheDriver;
 use Spatie\StructureDiscoverer\Cache\StaticDiscoverCacheDriver;
 use Spatie\StructureDiscoverer\Data\DiscoveredAttribute;
@@ -32,6 +33,7 @@ use Spatie\StructureDiscoverer\Tests\Fakes\FakeWithMultipleClassesSub;
 use Spatie\StructureDiscoverer\Tests\Fakes\Nested\FakeNestedClass;
 use Spatie\StructureDiscoverer\Tests\Fakes\Nested\FakeNestedInterface;
 use Spatie\StructureDiscoverer\Tests\Fakes\OtherNested\FakeOtherNestedClass;
+use Spatie\StructureDiscoverer\Tests\Fixtures\Models\FakeUser;
 use Spatie\StructureDiscoverer\Tests\Stubs\StubStructureScout;
 
 beforeEach(function () {
@@ -207,6 +209,14 @@ it('can discover classes extending a non included class', function () {
 
     expect($found)->toEqualCanonicalizing([
         FakeClassDepender::class,
+    ]);
+});
+
+it('can discover classes extending an autoloadable subclass outside the discovery path', function () {
+    $found = Discover::in(__DIR__.'/Fixtures/Models')->extending(Model::class)->get();
+
+    expect($found)->toEqualCanonicalizing([
+        FakeUser::class,
     ]);
 });
 

--- a/tests/StructureDiscovererTest.php
+++ b/tests/StructureDiscovererTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use Illuminate\Database\Eloquent\Model;
+
 use function Pest\Laravel\artisan;
 
-use Illuminate\Database\Eloquent\Model;
 use Spatie\StructureDiscoverer\Cache\FileDiscoverCacheDriver;
 use Spatie\StructureDiscoverer\Cache\StaticDiscoverCacheDriver;
 use Spatie\StructureDiscoverer\Data\DiscoveredAttribute;


### PR DESCRIPTION
Fixes #42

## Changes
- Include autoloadable parent class chains when resolving `extendsChain` for parents outside the discovery path.
- Add a regression fixture for a discovered model extending a package model that extends Eloquent `Model`.
- Preserve `withoutChains()` behavior by keeping subclass expansion inside chain resolution instead of the condition itself.

## Testing
- `vendor/bin/pest tests/StructureDiscovererTest.php --filter='autoloadable subclass'`
- `vendor/bin/pest tests/StructureDiscovererTest.php --filter='disable chains completely'`
- `composer test`
- `composer analyse`