### PR TITLE
Revert #43: model discovery chain expansion

### DIFF
--- a/src/Support/StructureChainResolver.php
+++ b/src/Support/StructureChainResolver.php
@@ -46,14 +46,7 @@ class StructureChainResolver
         }
 
         if (! array_key_exists($structure->extends, $discovered)) {
-            $parents = class_exists($structure->extends)
-                ? array_values(class_parents($structure->extends))
-                : [];
-
-            $structure->extendsChain = [
-                $structure->extends,
-                ...$parents,
-            ];
+            $structure->extendsChain = [$structure->extends];
 
             return;
         }

--- a/tests/Fixtures/Models/FakeUser.php
+++ b/tests/Fixtures/Models/FakeUser.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Spatie\StructureDiscoverer\Tests\Fixtures\Models;
-
-use Spatie\StructureDiscoverer\Tests\Fixtures\PackageModels\FakePackageUser;
-
-class FakeUser extends FakePackageUser
-{
-}

--- a/tests/Fixtures/PackageModels/FakePackageUser.php
+++ b/tests/Fixtures/PackageModels/FakePackageUser.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Spatie\StructureDiscoverer\Tests\Fixtures\PackageModels;
-
-use Illuminate\Database\Eloquent\Model;
-
-class FakePackageUser extends Model
-{
-}

--- a/tests/StructureDiscovererTest.php
+++ b/tests/StructureDiscovererTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use Illuminate\Database\Eloquent\Model;
-
 use function Pest\Laravel\artisan;
 
 use Spatie\StructureDiscoverer\Cache\FileDiscoverCacheDriver;
@@ -34,7 +32,6 @@ use Spatie\StructureDiscoverer\Tests\Fakes\FakeWithMultipleClassesSub;
 use Spatie\StructureDiscoverer\Tests\Fakes\Nested\FakeNestedClass;
 use Spatie\StructureDiscoverer\Tests\Fakes\Nested\FakeNestedInterface;
 use Spatie\StructureDiscoverer\Tests\Fakes\OtherNested\FakeOtherNestedClass;
-use Spatie\StructureDiscoverer\Tests\Fixtures\Models\FakeUser;
 use Spatie\StructureDiscoverer\Tests\Stubs\StubStructureScout;
 
 beforeEach(function () {
@@ -210,14 +207,6 @@ it('can discover classes extending a non included class', function () {
 
     expect($found)->toEqualCanonicalizing([
         FakeClassDepender::class,
-    ]);
-});
-
-it('can discover classes extending an autoloadable subclass outside the discovery path', function () {
-    $found = Discover::in(__DIR__.'/Fixtures/Models')->extending(Model::class)->get();
-
-    expect($found)->toEqualCanonicalizing([
-        FakeUser::class,
     ]);
 });
 


### PR DESCRIPTION
Reverts #43.

The previous fix for #42 turned out to be incorrect, so this restores the old chain resolution behavior while we take another look at the underlying model discovery issue.

## Testing
- `composer test`
- `composer analyse`